### PR TITLE
Bug fixes for benchmark scripts

### DIFF
--- a/benchmark_code/benchmark_profile.py
+++ b/benchmark_code/benchmark_profile.py
@@ -99,7 +99,7 @@ def run_profile(N, backend, scramble_data=False):
             input_data=InputData.flat(tmp["input_data"]["flat"]),  # Provide the flat input data from stage 1
             labels=Labels(root_nodes=tmp["labels"]["root_nodes"]),
             tt_function=tmp["tt_function"],  # Reuse pre-compiled JAX function
-            include_fail_nodes=True,
+            include_fail_nodes=False,
             include_warn_nodes=False,
             backend=backend,
         )
@@ -136,7 +136,7 @@ def run_profile(N, backend, scramble_data=False):
             specialized_environment=SpecializedEnvironment(
                 tt_dag=tmp["specialized_environment"]["tt_dag"]
             ),
-            include_fail_nodes=True,
+            include_fail_nodes=False,
             include_warn_nodes=False,
             backend=backend,
         )


### PR DESCRIPTION
- Stage 1 in `benchmark.py` now sets `include_fail_nodes=True`; we want to know how much time it takes to process the  `fail_if` nodes.

- Stages 2 and 3 now consistently `set include_fail_nodes=False` in both, `benchmark.py` and `benchmark_profile.py`.

- The peak memory reported in `benchmark.py` was just the final memory.

- Peak memory in `benchmark.py` is now also included in the final table.